### PR TITLE
Fixing error

### DIFF
--- a/qbfetch.py
+++ b/qbfetch.py
@@ -4,7 +4,7 @@ from qutebrowser.browser.qutescheme import add_handler
 from qutebrowser.utils import objreg, version as vs
 # from qutebrowser import __file__ as qtfile
 from qutebrowser import __version__ as qtver
-from qutebrowser.qt.core import QUrl
+from PyQt5.QtCore import QUrl
 # import traceback
 # import os
 


### PR DESCRIPTION
Errors occurred while reading config.py: 
Unhandled exception: No module named 'qutebrowser.qt.core'; 'qutebrowser.qt' is not a package 
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/qutebrowser/config/configfiles.py", line 928, in read_config_py
    exec(code, module.__dict__)
  File "/home/elbachir/.config/qutebrowser/qbfetch.py", line 6, in <module>
    from qutebrowser.qt.core import QUrl
ModuleNotFoundError: No module named 'qutebrowser.qt.core'; 'qutebrowser.qt' is not a package